### PR TITLE
Ubuntu support and removing dependency on aptbpo

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -10,7 +10,5 @@ class rrdcached::package {
 
   package {$rrdcached::package:
     ensure          => $package_ensure,
-    provider        => 'aptbpo',
-    install_options => { '-t' => 'squeeze-backports' },
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class rrdcached::params {
   $maxwait = '30'
 
   case $::operatingsystem {
-    'Debian': {
+    'Debian', 'Ubuntu': {
       $package = [ 'rrdcached' ]
       $config = '/etc/default/rrdcached'
       $service_name = 'rrdcached'


### PR DESCRIPTION
Thanks for your puppet module. It has saved me a lot of time.

I made a couple of simple changes that you might be interested in. The first being a very simple addition to allow the module to run with Ubuntu machines.

The second change removes the dependency on the aptbpo provider. Although I can see the value in using your aptbpo provider, I find the module more portable if it uses the standard package provider. For instance, I am running under Ubuntu and although your aptbpo provider would work seamlessly, the same could not be said for RedHat based systems.

In the interest of simplicity I removed the dependency on aptbpo provider rather than write additional clauses in package.pp for other distributions.

I did consider adding a simple clause to check to see if the aptbpo provider was installed but I could not find a simple way to achieve this.

Once again, thanks for a great module. It is simple and very well written.
